### PR TITLE
Draft: Added preview at request-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ publicRuntimeConfig: {
     roadiz: {
         baseURL: 'https://myroadizapi.test/api/1.0',
         apiKey: 'xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx',
-        preview: false,
+        allowClientPreview: true,
         debug: false,
         origin: 'https://mywebsite.test'
     }
@@ -58,3 +58,12 @@ async asyncData({ $roadiz, route, req }: Context): Promise<object | void> | obje
     }
 }
 ```
+
+### Client previewing
+
+If you enable `allowClientPreview` config, NuxtRoadizApi will append `_preview` and `token` query parameters to any
+API request to your Roadiz API. `_preview` parameter will be passed-through, and `token` parameter will be added as 
+`Authorization: Bearer ${token}` header.
+
+If your user is currently *previewing* with a JWT, `$roadiz.previewingJwt` (`RoadizPreviewJwt`) object will be available 
+to display information on your website.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,7 +24,7 @@ export class NuxtRoadizApi extends RoadizApi {
     private _context: Context
     private _previewing: boolean
     private _previewingJwt: RoadizPreviewJwt | null
-    private allowClientPreview: boolean
+    private _allowClientPreview: boolean
     private _origin?: string
 
     constructor(context: Context, config: RoadizPluginConfig) {
@@ -36,7 +36,7 @@ export class NuxtRoadizApi extends RoadizApi {
         this._origin = origin
         this._previewing = false
         this._previewingJwt = null
-        this.allowClientPreview = allowClientPreview || false
+        this._allowClientPreview = allowClientPreview || false
     }
 
     get context(): Context {
@@ -72,13 +72,13 @@ export class NuxtRoadizApi extends RoadizApi {
         /*
          * Pass through preview state and JWT token to Roadiz API
          */
-        if (this.allowClientPreview && this.context.req && this.context.req.url) {
+        if (this._allowClientPreview && this.context.req && this.context.req.url) {
             const currentUrl = new URL(this.context.req.url)
             if (
                 currentUrl.searchParams.has('_preview') &&
-                currentUrl.searchParams.get('_preview') == '1' &&
+                currentUrl.searchParams.get('_preview') === '1' &&
                 currentUrl.searchParams.has('token') &&
-                currentUrl.searchParams.get('token') != ''
+                currentUrl.searchParams.get('token') !== ''
             ) {
                 config.headers.params['_preview'] = '1'
                 config.headers.common.Authorization = `Bearer ${currentUrl.searchParams.get('token')}`

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,10 +3,18 @@ import { Inject } from '@nuxt/types/app'
 import RoadizApi from '@roadiz/abstract-api-client'
 import { AxiosRequestConfig } from 'axios'
 
+export interface RoadizPreviewJwt {
+    iat: number // issued at (Unix time)
+    exp: number // expiration time (Unix time)
+    roles: Array<string>
+    username: string
+}
+
 export interface RoadizPluginConfig {
     baseURL: string
     apiKey?: string
-    preview?: boolean
+    preview?: boolean // deprecated: Preview mode MUST be set at request time
+    allowClientPreview?: boolean
     debug?: boolean
     origin?: string
     defaults?: AxiosRequestConfig
@@ -14,15 +22,21 @@ export interface RoadizPluginConfig {
 
 export class NuxtRoadizApi extends RoadizApi {
     private _context: Context
+    private _previewing: boolean
+    private _previewingJwt: RoadizPreviewJwt | null
+    private allowClientPreview: boolean
     private _origin?: string
 
     constructor(context: Context, config: RoadizPluginConfig) {
-        const { baseURL, apiKey, preview, debug, origin, defaults } = config
+        const { baseURL, apiKey, preview, allowClientPreview, debug, origin, defaults } = config
 
         super(baseURL, { apiKey, preview, debug, defaults })
 
         this._context = context
         this._origin = origin
+        this._previewing = false
+        this._previewingJwt = null
+        this.allowClientPreview = allowClientPreview || false
     }
 
     get context(): Context {
@@ -31,6 +45,14 @@ export class NuxtRoadizApi extends RoadizApi {
 
     get origin(): string | undefined {
         return this._origin
+    }
+
+    get isPreviewing(): boolean {
+        return this._previewing
+    }
+
+    get previewingJwt(): RoadizPreviewJwt | null {
+        return this._previewingJwt
     }
 
     protected onApiRequest(config: AxiosRequestConfig): AxiosRequestConfig {
@@ -47,12 +69,48 @@ export class NuxtRoadizApi extends RoadizApi {
             }
         }
 
+        /*
+         * Pass through preview state and JWT token to Roadiz API
+         */
+        if (this.allowClientPreview && this.context.req && this.context.req.url) {
+            const currentUrl = new URL(this.context.req.url)
+            if (
+                currentUrl.searchParams.has('_preview') &&
+                currentUrl.searchParams.get('_preview') == '1' &&
+                currentUrl.searchParams.has('token') &&
+                currentUrl.searchParams.get('token') != ''
+            ) {
+                config.headers.params['_preview'] = '1'
+                config.headers.common.Authorization = `Bearer ${currentUrl.searchParams.get('token')}`
+                this._previewing = true
+                this._previewingJwt = this.getJwtPayload(currentUrl.searchParams.get('token'))
+            }
+        }
+
         if (process.server) {
             // Don't accept brotli encoding because Node can't parse it
             config.headers.common['accept-encoding'] = 'gzip, deflate'
         }
 
         return config
+    }
+
+    protected getJwtPayload(token: string | null): RoadizPreviewJwt {
+        if (token) {
+            const base64Url = token.split('.')[1]
+            const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+            const jsonPayload = decodeURIComponent(
+                atob(base64)
+                    .split('')
+                    .map((c) => {
+                        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+                    })
+                    .join('')
+            )
+
+            return JSON.parse(jsonPayload)
+        }
+        throw new Error('JWT token is null')
     }
 }
 


### PR DESCRIPTION
- Added `_preview` query param from Nuxt request and added `Authorization: Bearer token` from `token` query param
- Expose a `$roadiz.previewingJwt` object for displaying handy information on your website durung preview.